### PR TITLE
Fix:アイテム検索時に発生するエラーの修正

### DIFF
--- a/app/controllers/search_items_controller.rb
+++ b/app/controllers/search_items_controller.rb
@@ -4,21 +4,26 @@ class SearchItemsController < ApplicationController
     @keyword = params[:keyword]
     @items = []
     if @keyword.present?
-      @results = RakutenWebService::Ichiba::Product.search(keyword: @keyword, genreId: 101975)
+      @results = RakutenWebService::Ichiba::Product.search(keyword: @keyword, genreId: 101975)#楽天価格ナビ製品検索で渡されたkeywordを元に検索
 
       childe_categories = []
       @results.each do |result|
         childe_categories << result["genreId"]#検索結果のアイテムのジャンルIDを配列に挿入
       end
+
       parent_categories = []
       childe_categories.each do |c|
-        parent_categories << RakutenWebService::Ichiba::Genre[c]
+        parent_categories << RakutenWebService::Ichiba::Genre[c]#アイテム検索で取得したアイテムのジャンルIDをそれぞれ楽天ジャンルAPI検索にかけて，配列に挿入
       end
+
       categories = []
       parent_categories.each do |p|
-        categories << p.parents[2]["genreName"]#親のジャンルを取得
+        if p.parents[2].present?
+          categories << p.parents[2]["genreName"]#親のジャンルを取得
+        else
+          categories << nil
+        end
       end
-      
       @results.zip(categories) do |result, c|
         item = Item.new(read(result, c))
         @items << item


### PR DESCRIPTION
## 概要

特定のキーワードで検索した場合にアイテムのカテゴリーが取得できずに
エラーが発生していた（"テント"で検索した場合など）

### 原因
楽天のジャンルの構造は多層構造になっており，最下層のジャンル名(children)でカテゴリ分けをした場合，
30種類以上のカテゴリを生成してしまいカテゴリが細分化され過ぎてしまう。

なので楽天製品検索APIにてアイテムのジャンルIDを取得しそのジャンルIDを元に楽天ジャンル検索APIをかけ
1つ上の階層(parents)のジャンル名を取得し適度なカテゴリ分けを可能にする。

しかし，楽天製品検索APIにて取得したアイテムの中には他とは違うジャンルの階層構造をしたアイテムも存在しており
取得途中でエラーを吐いてしまう。

### 解決
元のジャンルIDから1つ上の階層のジャンルIDを取得する際に，条件分岐を設けることで解決https://github.com/yokota-daiki/camp_items_show/pull/67/commits/b2975ce4b7be24290e303b6e7cb4cee950843f87
