### PR TITLE
キャンプ場検索で結果に国外のキャンプ場が表示されるバグ修正

### DIFF
--- a/app/controllers/search_camps_controller.rb
+++ b/app/controllers/search_camps_controller.rb
@@ -7,7 +7,7 @@ class SearchCampsController < ApplicationController
 
     if keyword.present?
       client = GooglePlaces::Client.new(ENV['GOOGLE_API_KEY'])
-      results = client.spots_by_query(keyword, language: 'ja', types: 'campground')
+      results = client.spots_by_query(keyword, lat: 35.392, lng: 139.442, language: 'ja', types: 'campground', region: 'ja')
 
       results.each do |result|
         camp_field = CampField.new(read(result))


### PR DESCRIPTION
## 概要

本番環境でのみ日本の地名を指定した場合でも国外のキャンプ場が結果に表示される
原因は不明(おそらくリクエストを送るサーバー場所による？)

## 修正
Google placesで使用できるメソッド`spots_by_query`の引数に日本の緯度経度を指定
