### PR TITLE
行きたいキャンプ場リスト作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -101,6 +101,12 @@ img.icon-btn {
   font-family: 'Kaisei Decol', serif;
 }
 
+.bookmark-camps {
+  font-family: 'Kaisei Decol', serif;
+  margin-right: 420px;
+  margin-left: 420px;
+}
+
 //checklistページ
 .no-items {
   font-family: 'Kaisei Decol', serif;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,8 +104,7 @@ img.icon-btn {
 .bookmark-camps {
   font-family: 'Kaisei Decol', serif;
   font-size: 1.3rem;
-  margin-right: 400px;
-  margin-left: 400px;
+  
 }
 
 //checklistページ
@@ -164,11 +163,4 @@ img.icon-btn {
     padding-left: 0px;
     padding-right: 0px;
   }
-  //行きたいキャンプ場リスト
-  .bookmark-camps {
-    font-family: 'Kaisei Decol', serif;
-    font-size: large;
-    width: 100%;
-  }
-  
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -100,11 +100,12 @@ img.icon-btn {
 .camp-fields {
   font-family: 'Kaisei Decol', serif;
 }
-
+//キャンプ場行きたいリスト
 .bookmark-camps {
   font-family: 'Kaisei Decol', serif;
-  margin-right: 420px;
-  margin-left: 420px;
+  font-size: 1.3rem;
+  margin-right: 400px;
+  margin-left: 400px;
 }
 
 //checklistページ
@@ -163,4 +164,11 @@ img.icon-btn {
     padding-left: 0px;
     padding-right: 0px;
   }
+  //行きたいキャンプ場リスト
+  .bookmark-camps {
+    font-family: 'Kaisei Decol', serif;
+    font-size: large;
+    width: 100%;
+  }
+  
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -152,4 +152,9 @@ img.icon-btn {
     width: 170px;
     padding-top: 10px;
   }
+  //キャンプ投稿
+  .post-camp {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }

--- a/app/assets/stylesheets/search_box.scss
+++ b/app/assets/stylesheets/search_box.scss
@@ -1,7 +1,7 @@
 .search_container{
   box-sizing: border-box;
   padding-top: 20px;
-  padding-left: 40px;
+  padding-left: 25px;
 }
 .search_container input[type="text"]{
   border: 1px solid #999;

--- a/app/controllers/bookmark_camps_controller.rb
+++ b/app/controllers/bookmark_camps_controller.rb
@@ -12,7 +12,7 @@ class BookmarkCampsController < ApplicationController
   end
 
   def index
-    @bookmark_camps_fields = current_user.bookmark_camp_field.includes([:bookmark_camps])
+    @bookmark_camps_fields = current_user.bookmark_camp_field.includes([:bookmark_camps]).order(created_at: :desc).page(params[:page]).per(7)
   end
 
   private

--- a/app/controllers/bookmark_camps_controller.rb
+++ b/app/controllers/bookmark_camps_controller.rb
@@ -1,3 +1,21 @@
 class BookmarkCampsController < ApplicationController
 
+  def create
+    @camp_field = CampField.find_or_create_by(params_camp_field)
+    current_user.add_bookmark(@camp_field)
+  end
+
+  def destroy
+    @camp_field = current_user.bookmark_camps.find(params[:id]).camp_field
+    current_user.delete_bookmark(@camp_field)
+  end
+
+  def index
+  end
+
+  private
+
+  def params_camp_field
+    params.require(:camp_field).permit(:name, :latitude, :longitude, :address, :image)
+  end
 end

--- a/app/controllers/bookmark_camps_controller.rb
+++ b/app/controllers/bookmark_camps_controller.rb
@@ -1,0 +1,3 @@
+class BookmarkCampsController < ApplicationController
+
+end

--- a/app/controllers/bookmark_camps_controller.rb
+++ b/app/controllers/bookmark_camps_controller.rb
@@ -6,8 +6,9 @@ class BookmarkCampsController < ApplicationController
   end
 
   def destroy
-    @camp_field = current_user.bookmark_camps.find(params[:id]).camp_field
-    current_user.delete_bookmark(@camp_field)
+    camp_field = current_user.bookmark_camps.find(params[:id]).camp_field
+    current_user.delete_bookmark(camp_field)
+    redirect_to bookmark_camps_path, success: t('.success')
   end
 
   def index

--- a/app/controllers/bookmark_camps_controller.rb
+++ b/app/controllers/bookmark_camps_controller.rb
@@ -12,7 +12,7 @@ class BookmarkCampsController < ApplicationController
   end
 
   def index
-    @bookmark_camps_fields = current_user.bookmark_camp_field
+    @bookmark_camps_fields = current_user.bookmark_camp_field.includes([:bookmark_camps])
   end
 
   private

--- a/app/controllers/bookmark_camps_controller.rb
+++ b/app/controllers/bookmark_camps_controller.rb
@@ -11,6 +11,7 @@ class BookmarkCampsController < ApplicationController
   end
 
   def index
+    @bookmark_camps_fields = current_user.bookmark_camp_field
   end
 
   private

--- a/app/models/bookmark_camp.rb
+++ b/app/models/bookmark_camp.rb
@@ -1,4 +1,6 @@
 class BookmarkCamp < ApplicationRecord
   belongs_to :user
   belongs_to :camp_field
+
+  validates :user_id, uniqueness: { scope: :camp_field_id }
 end

--- a/app/models/bookmark_camp.rb
+++ b/app/models/bookmark_camp.rb
@@ -1,0 +1,4 @@
+class BookmarkCamp < ApplicationRecord
+  belongs_to :user
+  belongs_to :camp_field
+end

--- a/app/models/camp_field.rb
+++ b/app/models/camp_field.rb
@@ -1,2 +1,5 @@
 class CampField < ApplicationRecord
+  has_many :bookmark_camps, dependent: :destroy
+
+  validates :name, uniqueness: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,13 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
-  has_many :posts,      dependent: :destroy
-  has_many :checklists, dependent: :destroy
-  has_many :myitems,    dependent: :destroy
-  has_many :myitem_items, through: :myitems, source: :item
+  has_many :posts,          dependent: :destroy
+  has_many :checklists,     dependent: :destroy
+  has_many :myitems,        dependent: :destroy
+  has_many :myitem_items,        through: :myitems, source: :item
+  has_many :bookmark_camps, dependent: :destroy
+  has_many :bookmark_camp_field, through: :bookmark_camps, source: :camp_field
+
 
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
@@ -29,5 +32,18 @@ class User < ApplicationRecord
 
   def delete_myitem(item)
     myitems.delete(item)
+  end
+
+  def bookmark?(camp_field)
+    camp_field_id = CampField.find_by(name: camp_field.name)
+    bookmark_camp_field.include?(camp_field_id)
+  end
+
+  def add_bookmark(camp_field)
+    bookmark_camp_field << camp_field
+  end
+
+  def delete_bookmark(camp_field)
+    bookmark_camp_field.delete(camp_field)
   end
 end

--- a/app/views/bookmark_camps/_bookmark_camp_field.html.erb
+++ b/app/views/bookmark_camps/_bookmark_camp_field.html.erb
@@ -1,0 +1,21 @@
+<div class="card mb-4 mx-auto border border-secondary border-2" style="max-width: 1000px;">
+  <div class="row g-0">
+    <div class="col-md-6 py-4 px-4">
+      <% if bookmark_camp_field.image %>
+        <%= image_tag bookmark_camp_field.image, class: 'card img-fluid rounded-3', style: 'max-width: 100%; height: auto;' %>
+      <% end %>
+    </div>
+    <div class="col-md-6">
+      <div class="card-title mx-auto">
+        <h2 class="py-5 px-3"><%= image_tag 'tent.png' %><%= bookmark_camp_field.name %></h2>
+      </div>
+      <div class="card-text">
+        <p class="pb-2 px-3"><%= bookmark_camp_field.address.gsub(/日本、/,"") %></p>
+        <%= link_to "https://www.google.com/maps/search/?api=1&query=#{bookmark_camp_field.name}", target: :_blank, rel: "noopener noreferrer", class: 'px-3', style: 'color: black' do %>
+          <i class="fa-solid fa-earth-americas"></i>
+          Google Mapで表示する
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/bookmark_camps/_bookmark_camp_field.html.erb
+++ b/app/views/bookmark_camps/_bookmark_camp_field.html.erb
@@ -15,6 +15,9 @@
           <i class="fa-solid fa-earth-americas"></i>
           Google Mapで表示する
         <% end %>
+        <%= link_to bookmark_camp_path(bookmark_camp_field.bookmark_camps.find { |b| b.user_id == current_user.id }), method: :delete do %>
+          <i class="fa-solid fa-trash-can fa-lg" style="color: black;"></i>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/bookmark_camps/_bookmark_camp_field.html.erb
+++ b/app/views/bookmark_camps/_bookmark_camp_field.html.erb
@@ -15,7 +15,7 @@
           <i class="fa-solid fa-earth-americas"></i>
           Google Mapで表示する
         <% end %>
-        <%= link_to bookmark_camp_path(bookmark_camp_field.bookmark_camps.find { |b| b.user_id == current_user.id }), method: :delete do %>
+        <%= link_to bookmark_camp_path(bookmark_camp_field.bookmark_camps.find { |b| b.user_id == current_user.id }), method: :delete, id: "delete-btn-#{bookmark_camp_field.id}" do %>
           <i class="fa-solid fa-trash-can fa-lg" style="color: black;"></i>
         <% end %>
       </div>

--- a/app/views/bookmark_camps/create.js.erb
+++ b/app/views/bookmark_camps/create.js.erb
@@ -1,1 +1,1 @@
-$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith("<%= j(render "search_camps/unbookmark_camp", camp_field: @camp_field ) %>");
+$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith(`<i class="fa-solid fa-flag fa-lg"></i>`);

--- a/app/views/bookmark_camps/create.js.erb
+++ b/app/views/bookmark_camps/create.js.erb
@@ -1,1 +1,1 @@
-$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith(`<i class="fa-solid fa-flag fa-lg"></i>`);
+$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith(`<i class="fa-solid fa-flag fa-lg"></i>追加しました！`);

--- a/app/views/bookmark_camps/create.js.erb
+++ b/app/views/bookmark_camps/create.js.erb
@@ -1,0 +1,1 @@
+$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith("<%= j(render "search_camps/unbookmark_camp", camp_field: @camp_field ) %>");

--- a/app/views/bookmark_camps/destroy.js.erb
+++ b/app/views/bookmark_camps/destroy.js.erb
@@ -1,1 +1,0 @@
-$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith("<%= j(render "search_camps/bookmark_camp", camp_field: @camp_field ) %>");

--- a/app/views/bookmark_camps/destroy.js.erb
+++ b/app/views/bookmark_camps/destroy.js.erb
@@ -1,0 +1,1 @@
+$('#js-bookmark-btn-<%= @camp_field.name %>').replaceWith("<%= j(render "search_camps/bookmark_camp", camp_field: @camp_field ) %>");

--- a/app/views/bookmark_camps/index.html.erb
+++ b/app/views/bookmark_camps/index.html.erb
@@ -7,4 +7,5 @@
   <div class="content mx-auto pt-3">
       <%= render partial: 'bookmark_camp_field', collection: @bookmark_camps_fields %>
   </div>
+  <%= paginate @bookmark_camps_fields %>
 </div>

--- a/app/views/bookmark_camps/index.html.erb
+++ b/app/views/bookmark_camps/index.html.erb
@@ -1,0 +1,10 @@
+<% content_for(:title, t(".title")) %>
+<%= render 'shared/links' %>
+<div class="container">
+  <div class="text-center">
+    <h1 class="title"><%= t '.title' %></h1>
+  </div>
+  <div class="content mx-auto pt-3">
+      <%= render partial: 'bookmark_camp_field', collection: @bookmark_camps_fields %>
+  </div>
+</div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -28,7 +28,13 @@
         <% end %>
       </p>
     </div>
-    <div class="card-footer" style="height: 50px;">
+    <div class="post-camp card-footer px-1" style="height: 50px;">
+      <div class="float-left">
+        <%= link_to "https://www.google.com/maps/search/?api=1&query=#{post.camp_field}", target: :_blank, rel: "noopener noreferrer", style: 'color: black' do %>
+          <small><i class="fa-solid fa-earth-americas"></i>
+          GoogleMapで表示</small>
+        <% end %>
+      </div>
       <div class="float-right">
         <div class="d-flex lex-row mb-3">
           <div class="p-2">

--- a/app/views/search_camps/_bookmark_buttons.html.erb
+++ b/app/views/search_camps/_bookmark_buttons.html.erb
@@ -1,0 +1,5 @@
+<% if current_user.bookmark?(camp_field) %>
+  <i class="fa-solid fa-flag fa-lg"></i>
+<% else %>
+  <%= render 'bookmark_camp', { camp_field: camp_field } %>
+<% end %>

--- a/app/views/search_camps/_bookmark_camp.html.erb
+++ b/app/views/search_camps/_bookmark_camp.html.erb
@@ -1,6 +1,7 @@
 <div id="js-bookmark-btn-<%= camp_field.name %>">  
   <%= link_to bookmark_camps_path(camp_field: { name: camp_field.name, latitude: camp_field.latitude, longitude: camp_field.longitude, address: camp_field.address, image: camp_field.image }), 
-                                  method: :post, remote: true, style: 'color: black' do %>
+                                  method: :post, remote: true, class: 'px-3', style: 'color: black' do %>
     <i class="fa-regular fa-flag fa-lg"></i>
+    行きたいリストに追加する
   <% end %>
 </div>

--- a/app/views/search_camps/_bookmark_camp.html.erb
+++ b/app/views/search_camps/_bookmark_camp.html.erb
@@ -1,0 +1,6 @@
+<div id="js-bookmark-btn-<%= camp_field.name %>">  
+  <%= link_to bookmark_camps_path(camp_field: { name: camp_field.name, latitude: camp_field.latitude, longitude: camp_field.longitude, address: camp_field.address, image: camp_field.image }), 
+                                  method: :post, remote: true, style: 'color: black' do %>
+    <i class="fa-regular fa-flag fa-lg"></i>
+  <% end %>
+</div>

--- a/app/views/search_camps/_camp_field.html.erb
+++ b/app/views/search_camps/_camp_field.html.erb
@@ -15,6 +15,7 @@
           <i class="fa-solid fa-earth-americas"></i>
           Google Mapで表示する
         <% end %>
+        <%= render 'bookmark_buttons', camp_field: camp_field %>
       </div>
     </div>
   </div>

--- a/app/views/search_camps/_camp_field.html.erb
+++ b/app/views/search_camps/_camp_field.html.erb
@@ -11,6 +11,10 @@
       </div>
       <div class="card-text">
         <p class="pb-2 px-3"><%= camp_field.address.gsub(/日本、/,"") %></p>
+        <%= link_to "https://www.google.com/maps/search/?api=1&query=#{camp_field.name}", target: :_blank, rel: "noopener noreferrer", class: 'px-3', style: 'color: black' do %>
+          <i class="fa-solid fa-earth-americas"></i>
+          Google Mapで表示する
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/search_camps/_unbookmark_camp.html.erb
+++ b/app/views/search_camps/_unbookmark_camp.html.erb
@@ -1,3 +1,0 @@
-<%= link_to bookmark_camps_path(camp_field), method: :delete, id: "js-bookmark-btn-#{camp_field.name}", remote: true, style: 'color: black' do %>
-  <i class="fa-solid fa-flag fa-lg"></i>
-<% end %>

--- a/app/views/search_camps/_unbookmark_camp.html.erb
+++ b/app/views/search_camps/_unbookmark_camp.html.erb
@@ -1,0 +1,3 @@
+<%= link_to bookmark_camps_path(camp_field), method: :delete, id: "js-bookmark-btn-#{camp_field.name}", remote: true, style: 'color: black' do %>
+  <i class="fa-solid fa-flag fa-lg"></i>
+<% end %>

--- a/app/views/search_camps/search.html.erb
+++ b/app/views/search_camps/search.html.erb
@@ -12,13 +12,14 @@
           <% end %>
         <% end %>
       </div>
+      <div class="bookmark-camps">
+        <%= link_to '行きたいキャンプ場リスト', bookmark_camps_path %>
+      </div>
     </div>
   </div>
   <div id="map" class="card border-dark mt-3"></div>
   <div class="content mx-auto pt-3">
-    <% if @camp_fields %>
-      <%= render partial: 'camp_field', collection: @camp_fields %>
-    <% end %>
+    <%= render partial: 'camp_field', collection: @camp_fields %>
   </div>
 </div>
 

--- a/app/views/search_camps/search.html.erb
+++ b/app/views/search_camps/search.html.erb
@@ -12,8 +12,10 @@
           <% end %>
         <% end %>
       </div>
-      <div class="bookmark-camps">
-        <%= link_to '行きたいキャンプ場リスト', bookmark_camps_path %>
+      <div class="bookmark-camps py-3">
+        <%= link_to bookmark_camps_path, style: 'color: black;' do %>
+          <h4><i class="fa-regular fa-flag"></i>行きたいキャンプ場リスト</h4>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/search_camps/search.html.erb
+++ b/app/views/search_camps/search.html.erb
@@ -14,7 +14,7 @@
       </div>
       <div class="bookmark-camps py-3">
         <%= link_to bookmark_camps_path, style: 'color: black;' do %>
-          <h4><i class="fa-regular fa-flag"></i>行きたいキャンプ場リスト</h4>
+          <i class="fa-regular fa-flag"></i>行きたいキャンプ場リスト
         <% end %>
       </div>
     </div>

--- a/app/views/search_camps/search.html.erb
+++ b/app/views/search_camps/search.html.erb
@@ -11,11 +11,11 @@
             <i class="fa-solid fa-magnifying-glass fa-lg mb-1"></i>
           <% end %>
         <% end %>
-      </div>
-      <div class="bookmark-camps py-3">
-        <%= link_to bookmark_camps_path, style: 'color: black;' do %>
-          <i class="fa-regular fa-flag"></i>行きたいキャンプ場リスト
-        <% end %>
+        <div class="bookmark-camps py-3">
+          <%= link_to bookmark_camps_path, style: 'color: black;' do %>
+            <i class="fa-regular fa-flag"></i>行きたいキャンプ場リスト
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/static_page/_post.html.erb
+++ b/app/views/static_page/_post.html.erb
@@ -21,6 +21,12 @@
     <% else %>
       <%= image_tag 'default_campimage.JPG', size: '350x330', class: 'card-img-top' %>
     <% end %>
+    <div class="card-body py-2">
+      <%= link_to "https://www.google.com/maps/search/?api=1&query=#{post.camp_field}", target: :_blank, rel: "noopener noreferrer", class: 'px-3', style: 'color: black' do %>
+        <i class="fa-solid fa-earth-americas"></i>
+        Google Mapで表示する
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -96,6 +96,8 @@ ja:
   bookmark_camps:
     index:
       title: '行きたいキャンプ場リスト'
+    destroy:
+      success: '削除しました'
   admin:
     users:
       index:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -93,6 +93,9 @@ ja:
     update:
       success: 'パスワードを再設定しました'
       fail: 'パスワードの再設定に失敗しました'
+  bookmark_camps:
+    index:
+      title: '行きたいキャンプ場リスト'
   admin:
     users:
       index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
   resources :password_resets, only: %i[new create edit update]
   resources :myitems, only: %i[create destroy]
+  resources :bookmark_camps, only: %i[create destroy index]
   namespace :admin do
     resources :users, only: %i[index edit update destroy]
     resources :posts, only: %i[index destroy]

--- a/db/migrate/20220928064438_create_bookmark_camps.rb
+++ b/db/migrate/20220928064438_create_bookmark_camps.rb
@@ -1,0 +1,11 @@
+class CreateBookmarkCamps < ActiveRecord::Migration[6.1]
+  def change
+    create_table :bookmark_camps do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :camp_field, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :bookmark_camps, %i[user_id camp_field_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_18_160435) do
+ActiveRecord::Schema.define(version: 2022_09_28_064438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,16 @@ ActiveRecord::Schema.define(version: 2022_08_18_160435) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "bookmark_camps", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "camp_field_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["camp_field_id"], name: "index_bookmark_camps_on_camp_field_id"
+    t.index ["user_id", "camp_field_id"], name: "index_bookmark_camps_on_user_id_and_camp_field_id", unique: true
+    t.index ["user_id"], name: "index_bookmark_camps_on_user_id"
   end
 
   create_table "camp_fields", force: :cascade do |t|
@@ -121,6 +131,8 @@ ActiveRecord::Schema.define(version: 2022_08_18_160435) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "bookmark_camps", "camp_fields"
+  add_foreign_key "bookmark_camps", "users"
   add_foreign_key "checklist_items", "checklists"
   add_foreign_key "checklist_items", "items"
   add_foreign_key "checklists", "users"

--- a/spec/factories/bookmark_camps.rb
+++ b/spec/factories/bookmark_camps.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bookmark_camp do
-    user { nil }
-    camp_field { nil }
+    association :user
+    association :camp_field
   end
 end

--- a/spec/factories/bookmark_camps.rb
+++ b/spec/factories/bookmark_camps.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :bookmark_camp do
+    user { nil }
+    camp_field { nil }
+  end
+end

--- a/spec/factories/camp_fields.rb
+++ b/spec/factories/camp_fields.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :camp_field do
-    name { 'MyString' }
-    lat { 1.5 }
-    lng { 1.5 }
-    adrress { 'MyString' }
+    name { '洪庵キャンプ場' }
+    latitude { 1.5 }
+    longitude { 1.5 }
+    address { 'MyString' }
   end
 end

--- a/spec/models/bookmark_camp_spec.rb
+++ b/spec/models/bookmark_camp_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe BookmarkCamp, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/bookmark_camps_spec.rb
+++ b/spec/requests/bookmark_camps_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "BookmarkCamps", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/system/bookmark_cmap_fields_spec.rb
+++ b/spec/system/bookmark_cmap_fields_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "BookmarkCmapFields", type: :system do
+  let(:user) { create(:user) }
+  let!(:camp_field) { create(:camp_field) }
+  let!(:bookmark_camp_field) { create(:bookmark_camp, user:, camp_field:) }
+  before { login(user) }
+
+  describe 'キャンプ場検索ページへ' do
+    context '行きたいキャンプ場リストボタンを押下' do
+      it 'ボタンが選択済みに変わる' do
+        visit search_camps_path
+        fill_in 'keyword', with: '洪庵キャンプ場'
+        click_on 'button'
+        click_on '行きたいリストに追加する', match: :first
+        expect(page).to have_content '追加しました'
+      end
+    end
+  end
+
+  describe '行きたいキャンプ場リストへ遷移' do
+    it '登録したキャンプ場が表示される' do
+      visit bookmark_camps_path
+      expect(page).to have_content '洪庵キャンプ場'
+    end
+
+    it '登録したキャンプ場を正常に削除できる' do
+      visit bookmark_camps_path
+      click_on "delete-btn-#{bookmark_camp_field.id}"
+      expect(page).to_not have_content camp_field.name
+    end
+  end
+end

--- a/spec/system/search_camps_spec.rb
+++ b/spec/system/search_camps_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'SearchCamps', type: :system do
   describe 'キャンプ場検索ページへ遷移' do
     context 'キャンプ場検索' do
-      fit '正常に検索できる' do
+      it '正常に検索できる' do
         visit search_camps_path
         fill_in 'keyword', with: '北海道'
         find('.fa-magnifying-glass').click


### PR DESCRIPTION
## 概要

行きたいキャンプ場リストページの作成
キャンプ場検索後それぞれのキャンプ場にGoogleMapへの検索後リンク及び
行きたいキャンプ場への登録ボタンの作成

userテーブルとcamp_fieldテーブルの中間テーブルbookmark_campsテーブルを作成し，
行きたいリストを管理

行きたいリストへの登録は非同期で作成